### PR TITLE
docs(readme): fix truncated sentence in Google Workspace example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Below example is based on the
 [DNS Basics](https://support.google.com/a/answer/48090?hl=en) support article.
 When going through the domain setup wizard within the Google Workspace Admin,
 you are likely to be given a slightly different list of MX records, and
-obviously
+obviously you should use the ones that are given to you by Google.
 
 Also make sure you generate your own domain key from under Apps > Google
 Workspace > Gmail > Authenticate Email.


### PR DESCRIPTION
## Summary
- The sentence about MX records in the Google Workspace example was cut off, leaving an incomplete thought ("and obviously" with no continuation).
- Completed the sentence to advise users to use the MX records given by Google.

## Test plan
- [x] Verify the README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)